### PR TITLE
Python 3 support for parsing JUMBF boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ their contents.
   the JPEG XS file format. Additionally supported flags:
 
     ```-C```, ```--ignore-codestream```: Don't parse the Codestream boxes.
+    ```-B <limit>```, ```--buffer-print-limit (limit)```: Output hex dump of
+    application boxes larger than the specified size (default 256 bytes)
 
 * ```jp2box.py```
 

--- a/icc.py
+++ b/icc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 """
 JPEG codestream-parser (All-JPEG Codestream/File Format Parser Tools)

--- a/jp2box.py
+++ b/jp2box.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 """
 JPEG codestream-parser (All-JPEG Codestream/File Format Parser Tools)
@@ -89,7 +91,7 @@ class JP2Box:
         elif len(length) < 4:
             raise UnexpectedEOF()
         length = ordl(length)
-        id = self.infile.read(4)
+        id = self.infile.read(4).decode('ascii')
         if len(id) < 4:
             raise UnexpectedEOF
         self.offset += 8

--- a/jp2codestream.py
+++ b/jp2codestream.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 """
 JPEG codestream-parser (All-JPEG Codestream/File Format Parser Tools)

--- a/jp2file.py
+++ b/jp2file.py
@@ -2141,7 +2141,9 @@ def superbox_hook(box, id, length):
                 jxr = JXRCodestream(box.infile, 1)
                 jxr.parse()
             elif ordw(type[0:2]) == 0xffd8:
-                cs = JPGCodestream(indent=box.indent + 1, hook=superbox_hook)
+                cs = JPGCodestream(
+                    indent=box.indent + 1, hook=superbox_hook,
+                    buffer_print_limit=buffer_print_limit)
                 cs.stream_parse(box.infile, box.offset)
             elif ordw(type[0:2]) == 0xff10:
                 cs = JXSCodestream(indent=box.indent + 1)
@@ -2375,12 +2377,15 @@ def superbox_hook(box, id, length):
 
 
 ignore_codestream = False
+buffer_print_limit = 256
 if __name__ == "__main__":
     # Read Arguments
-    args, files = getopt.getopt(sys.argv[1:], "C", "ignore-codestream")
+    args, files = getopt.getopt(sys.argv[1:], "CB:", ["ignore-codestream", "buffer-print-limit="])
     for (o, a) in args:
         if o in ("-C", "--ignore-codestream"):
             ignore_codestream = True
+        if o in ("-B", "--buffer-print-limit"):
+            buffer_print_limit = int(a)
 
     if len(files) != 1:
         print("Usage: [OPTIONS] %s FILE" % (sys.argv[0]))
@@ -2400,7 +2405,7 @@ if __name__ == "__main__":
             jp2 = JP2Codestream()
             jp2.stream_parse(file, 0)
         elif ordw(type) == 0xffd8:
-            jpg = JPGCodestream(hook=superbox_hook)
+            jpg = JPGCodestream(hook=superbox_hook, buffer_print_limit=buffer_print_limit)
             jpg.stream_parse(file, 0)
         elif ordw(type) == 0xff10:
             jxs = JXSCodestream()

--- a/jp2file.py
+++ b/jp2file.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 """
 JPEG codestream-parser (All-JPEG Codestream/File Format Parser Tools)
@@ -2106,7 +2108,7 @@ def parse_json_box(box, buf):
     s = buf
     if s[len(s) - 1] == "\0":
         s = s[:len(s) - 2]
-    box.print_indent(s)
+    box.print_indent(s.decode('utf-8'))
 
 
 def parse_superbox(box, boxtype):

--- a/jp2utils.py
+++ b/jp2utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 """
 JPEG codestream-parser (All-JPEG Codestream/File Format Parser Tools)
@@ -118,7 +120,7 @@ def convert_hex(buf, indent=0, sec_indent=-1, plain_text=False, single_line=True
                 line = ""
                 buff = "  "
             line += " " * indent
-        buff += chrb(buf[i]) if 32 <= ordb(buf[i]) < 127 else "."
+        buff += chr(buf[i]) if 32 <= ordb(buf[i]) < 127 else "."
         line += "%02x " % (ordb(buf[i]))
     if plain_text:
         line += "   " * ((16 - (len(buf) % 16)) % 16) + buff

--- a/jpgcodestream.py
+++ b/jpgcodestream.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 """
 JPEG codestream-parser (All-JPEG Codestream/File Format Parser Tools)
@@ -255,7 +257,7 @@ class JPGCodestream(BaseCodestream):
         self._end_marker()
 
     def parse_APP(self, idx):
-        if idx == 11 and self.buffer[4:6] == "JP":
+        if idx == 11 and self.buffer[4:6] == b'JP':
             self._new_marker("APP11", "JPEG XT Extension Marker")
             segment = BoxSegment(self.buffer, self.offset)
             self.boxlist.addBoxSegment(segment)

--- a/jpgcodestream.py
+++ b/jpgcodestream.py
@@ -19,7 +19,7 @@ class JPGCodestream(BaseCodestream):
     JPEG Codestream class.
     """
 
-    def __init__(self, indent=0, hook=None, offset=0):
+    def __init__(self, indent=0, hook=None, offset=0, buffer_print_limit=256):
         super(JPGCodestream, self).__init__(indent=indent)
         assert hook is not None
         self.datacount = 0
@@ -32,6 +32,7 @@ class JPGCodestream(BaseCodestream):
         self.superhook = hook
         self.buffer = None
         self.pos = 0
+        self.buffer_print_limit = buffer_print_limit
 
     def load_marker(self, file, marker):
         mrk = ordw(marker[0:2])
@@ -266,7 +267,7 @@ class JPGCodestream(BaseCodestream):
                 box.parse(self.superhook)
         else:
             self._new_marker(("APP%x" % idx), ("Application marker #%d" % idx))
-            if len(self.buffer) < 256:
+            if len(self.buffer) < self.buffer_print_limit:
                 print_hex(self.buffer)
         self._end_marker()
 

--- a/jpgxtbox.py
+++ b/jpgxtbox.py
@@ -1,10 +1,12 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 """
 JPEG codestream-parser (All-JPEG Codestream/File Format Parser Tools)
 See LICENCE.txt for copyright and licensing conditions.
 """
 from __future__ import print_function, division
-from io import StringIO
+from io import BytesIO
 
 from jp2utils import ordw, ordl, ordq, chrl, chrq, InvalidBoxSize, BoxSizesInconsistent
 from jp2box import JP2Box
@@ -84,7 +86,7 @@ class BoxList:
             # offset = sortedlist[0].offset
             for seg in sortedlist:
                 buf = buf + seg.buffer
-            string_stream = StringIO(buf)
-            box = JP2Box(None, string_stream)
+            bytes_stream = BytesIO(buf)
+            box = JP2Box(None, bytes_stream)
             box.indent = indent
             return box

--- a/jxrfile.py
+++ b/jxrfile.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 """
 JPEG codestream-parser (All-JPEG Codestream/File Format Parser Tools)

--- a/jxscodestream.py
+++ b/jxscodestream.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # -*- coding: utf-8 -*-
 """
 JPEG codestream-parser (All-JPEG Codestream/File Format Parser Tools)


### PR DESCRIPTION
I found a few places where the Python3 port needed to be updated to handle parsing files containing JUMBF boxes.

FYI I'm looking at files from the Content Authenticity Initiative, e.g. https://images.starlinglab.org/fs1/HEALTHCORONAVIRUSUSAOREGON_SALEM_08-cai.jpg

Feel free to make any fixes you deem necessary.